### PR TITLE
Aliniere parametrii verify_auth() la documentatie

### DIFF
--- a/netopia_sdk/payment.py
+++ b/netopia_sdk/payment.py
@@ -42,11 +42,11 @@ class PaymentService:
         endpoint = "/operation/status"
         return self.transport.send_request(endpoint, request, StatusResponse)
 
-    def verify_auth(self, auth_token: str, ntpID: str, pa_res: str) -> VerifyAuthResponse:
+    def verify_auth(self, authenticationToken: str, ntpID: str, formData: dict) -> VerifyAuthResponse:
         request = PaymentVerifyAuthParam(
-            authenticationToken=auth_token,
+            authenticationToken=authenticationToken,
             ntpID=ntpID,
-            formData={"paRes": pa_res},
+            formData=formData,
         )
 
         endpoint = "/payment/card/verify-auth"


### PR DESCRIPTION
### 🔧 Ce am modificat?
- Înlocuit `auth_token` cu `authenticationToken` pentru a respecta documentația oficială (`README.md`).
- Acceptat `formData` ca dicționar, eliminând necesitatea de a procesa manual `paRes`.
- Alinierea parametrilor `verify_auth()` astfel încât să corespundă modului în care funcția este apelată în documentație.

### 🛠 Cum am testat?
- Am verificat că apelul `verify_auth()` funcționează corect fără erori.
- Nu mai apare eroarea `got an unexpected keyword argument 'authenticationToken'`.