### PR TITLE
incremented minor version to fix caching problems after last changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="netopia-sdk",
-    version="2.0.5",
+    version="2.0.6",
     packages=find_packages(),
     install_requires=[
         "requests>=2.28.0",


### PR DESCRIPTION
The previous pull request was merged (thanks for accepting it) without incrementing the version of the python package. 
This leads to 2 version of the sdk having the same version so all the caches in the Internet that already contain 2.0.5 version of the sdk will not update themselves so the last change will not be visible for quite some time. 

The easiest fix is to bump the minor version of the sdk. 